### PR TITLE
[WIP] Coverlet tool execution

### DIFF
--- a/src/Cake.Coverlet/CoverletAliases.cs
+++ b/src/Cake.Coverlet/CoverletAliases.cs
@@ -1,4 +1,4 @@
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
 using Cake.Common.Tools.DotNetCore;
@@ -34,6 +34,15 @@ namespace Cake.Coverlet
             var currentCustomization = settings.ArgumentCustomization;
             settings.ArgumentCustomization = (args) => ProcessArguments(context, currentCustomization?.Invoke(args) ?? args, project, coverletSettings);
             context.DotNetCoreTest(project.FullPath, settings);
+        }
+
+        public static void DotNetCoreTool(this ICakeContext context, IEnumerable<FilePath> testFiles, CoverletToolSettings settings)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            if (settings == null)
+                settings = new CoverletToolSettings();
+            new CoverletTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools).Run(testFiles, settings);
         }
 
         private static ProcessArgumentBuilder ProcessArguments(

--- a/src/Cake.Coverlet/CoverletTool.cs
+++ b/src/Cake.Coverlet/CoverletTool.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Coverlet
+{
+    public sealed class CoverletTool : DotNetCoreTool<CoverletToolSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Cake.Common.Tools.DotNetCore.VSTest.DotNetCoreVSTester" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public CoverletTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+          : base(fileSystem, environment, processRunner, tools)
+        {
+            this._environment = environment;
+        }
+
+        public void Run(IEnumerable<FilePath> testFiles, CoverletToolSettings settings)
+        {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+            if (testFiles == null || !testFiles.Any<FilePath>())
+                throw new ArgumentNullException(nameof(testFiles));
+            this.RunCommand(settings, this.GetArguments(testFiles, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> testFiles, CoverletToolSettings settings)
+        {
+            var argumentBuilder = this.CreateArgumentBuilder(settings);
+            
+            throw new NotImplementedException();
+
+            return argumentBuilder;
+        }
+    }
+
+    public class CoverletToolSettings : DotNetCoreSettings
+    {
+        public CoverletSettings CoverletSettings { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #7

At first I was just going to quickly rip what I implemented here: https://github.com/octokit/octokit.net/pull/1866

But then I ended up looking at decompiled sources of some methods and noticed how Cake handles calling dotnet tools so I quickly made a stub. I could use your help to finish filling it in as I'm pretty new to cake and coverlet.

I don't have the time to finish right now, but I'm just not sure about the arguments. I guess I'm just not sure If the functionality in `CoverletAliases.ProcessArguments` will be correct.

Also I'm using Cake.Frosting, so I just need the methods implemented. I believe you might have some scripts to test that you can adapt to testing as a `dotnet tool`.

#### Todo:
- [ ] Complete arguments to send to `dotnet tool`
   https://github.com/StanleyGoldman/Cake.Coverlet/blob/8ec8e6938e9eaf749f198fdc7b52224da72d3462/src/Cake.Coverlet/CoverletTool.cs#L38-L45
- [ ] Adapt existing tests (?)

#### Reference material

https://github.com/cake-build/cake/blob/develop/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs#L1043-L1057

https://github.com/cake-build/cake/blob/develop/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs

https://github.com/cake-build/cake/blob/develop/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs

