### PR TITLE
Add Exclude By Attribute support to command line

### DIFF
--- a/src/Cake.Coverlet/ArgumentsProcessor.cs
+++ b/src/Cake.Coverlet/ArgumentsProcessor.cs
@@ -60,6 +60,11 @@ namespace Cake.Coverlet
                 builder.AppendPropertyList(nameof(CoverletSettings.Exclude), settings.Exclude);
             }
 
+            if (settings.ExcludeByAttribute.Count > 0)
+            {
+                builder.AppendPropertyList(nameof(CoverletSettings.ExcludeByAttribute), settings.ExcludeByAttribute);
+            }
+
             if (settings.MergeWithFile != null && settings.MergeWithFile.GetExtension() == ".json")
             {
                 builder.AppendMSBuildPropertyQuoted("MergeWith", settings.MergeWithFile.MakeAbsolute(cakeEnvironment).FullPath);
@@ -111,6 +116,11 @@ namespace Cake.Coverlet
             if (settings.ExcludeByFile.Count > 0)
             {
                 builder.AppendSwitchQuoted("--exclude-by-file", settings.ExcludeByFile);
+            }
+
+            if (settings.ExcludeByAttribute.Count > 0)
+            {
+                builder.AppendSwitchQuoted("--exclude-by-attribute", settings.ExcludeByAttribute);
             }
 
             if (settings.Exclude.Count > 0)

--- a/src/Cake.Coverlet/CoverletSettings.cs
+++ b/src/Cake.Coverlet/CoverletSettings.cs
@@ -59,6 +59,11 @@ namespace Cake.Coverlet
         public List<string> ExcludeByFile { get; set; } = new List<string>();
 
         /// <summary>
+        /// Gets or sets the list of files to exclude
+        /// </summary>
+        public List<string> ExcludeByAttribute { get; set; } = new List<string>();
+
+        /// <summary>
         /// Gets or sets the exclusion filters
         /// </summary>
         public List<string> Exclude { get; set; } = new List<string>();
@@ -94,6 +99,17 @@ namespace Cake.Coverlet
         public CoverletSettings WithFileExclusion(string file)
         {
             ExcludeByFile.Add(file);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a attribute to the list of attribute to exclude
+        /// </summary>
+        /// <param name="attribute">The attribute to exclude</param>
+        /// <returns></returns>
+        public CoverletSettings WithAttributeExclusion(string attribute)
+        {
+            ExcludeByAttribute.Add(attribute);
             return this;
         }
 
@@ -155,6 +171,7 @@ namespace Cake.Coverlet
                 CoverletOutputDirectory = CoverletOutputDirectory == null ? null : DirectoryPath.FromString(CoverletOutputDirectory.FullPath),
                 CoverletOutputName = CoverletOutputName,
                 ExcludeByFile = new List<string>(ExcludeByFile),
+                ExcludeByAttribute = new List<string>(ExcludeByAttribute),
                 Exclude = new List<string>(Exclude),
                 MergeWithFile = MergeWithFile == null ? null : FilePath.FromString(MergeWithFile.FullPath),
                 OutputTransformer = OutputTransformer

--- a/test/Cake.Coverlet.Tests/CoverletToolTest.cs
+++ b/test/Cake.Coverlet.Tests/CoverletToolTest.cs
@@ -28,6 +28,26 @@ namespace Cake.Coverlet.Tests
         }
 
         [Fact]
+        public void ExcludeByAttribute_Should_Be_Passed()
+        {
+            _fixture.Settings = new CoverletSettings();
+            _fixture.TestFile = "./test/Cake.Coverlet.Tests/bin/Debug/netcoreapp2.1/Cake.Coverlet.Tests.dll";
+            _fixture.TestProject = "./test/Cake.Coverlet.Tests/";
+            _fixture.Settings.WithAttributeExclusion("abc.def");
+            _fixture.Settings.WithAttributeExclusion("abc2.def");
+
+            var result = _fixture.Run();
+
+            Console.WriteLine(result.Args);
+
+            result.Args.Should().StartWith("\"/Working/test/Cake.Coverlet.Tests/bin/Debug/netcoreapp2.1/Cake.Coverlet.Tests.dll\"");
+            result.Args.Should().Contain("--targetargs \"test /Working/test/Cake.Coverlet.Tests --no-build\"");
+            result.Args.Should().Contain("--format json");
+            result.Args.Should().Contain("--exclude-by-attribute \"abc.def\"");
+            result.Args.Should().Contain("--exclude-by-attribute \"abc2.def\"");
+        }
+
+        [Fact]
         public void OutputFormat_Supports_TeamCity()
         {
             _fixture.Settings = new CoverletSettings 


### PR DESCRIPTION
At the moment there is no support for exclude by attribute which coverlet does support. 

Added that support.

Fixes #20 