### PR TITLE
Changes as per per the automated audit

### DIFF
--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.28.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.58" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -18,7 +18,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <PackageProjectUrl>https://github.com/romanx/Cake.Coverlet</PackageProjectUrl>
     <PackageLicenseFile>licence.md</PackageLicenseFile>
-    <PackageIconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</PackageIconUrl>
+    <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
     <DebugType>portable</DebugType>
     <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.28.0" />
+    <PackageReference Include="Cake.Common" Version="0.28.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.58" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -31,7 +31,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.28.0" />
     <PackageReference Include="Cake.Common" Version="0.28.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.58" PrivateAssets="All" />

--- a/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
+++ b/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Testing" Version="0.30.0" />
+    <PackageReference Include="Cake.Common" Version="0.33.0" />
+    <PackageReference Include="Cake.Testing" Version="0.33.0" />
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.33.0" />
+</packages>


### PR DESCRIPTION
The changes in this PR is made as per the recommended changes detailed in the automated audit (#24)

### What was changed
- The icon url was changed from using rawgit, to use jsdelivr instead.
  The is more or less an obligatory change, as rawgit is shutting down, and jsdelivr is the recommended cdn to use for addins.
- The dependency for Cake.Core was removed. This dependency was removed because Cake.Common already depends on Cake.Core and as such it will be pulled in during build.
- Cake.Common was made an Private Asset. This change was mainly done because it is not needed to be listed as a dependency when pushing the package (Exactly why this is recommended to be set to private I do not know. This would be a question to the develops of Cake).
- All Cake dependencies was updated to version 0.33.0, this is the recommended version to target, due to some breaking changes implemented in that version.
- Cake.Common was added as a dependency to the Unit Testing library, without this dependency I was unable to build the projects (could possibly be one of the breaking changes in the latest version of Cake. Uncertain)
- Added package configuration file to pin the version of cake used when building the project, this is only a recommended change and I can remove the change if desired.

/CC @Romanx 