### PR TITLE
Fix passing directories with spaces to dotnet test call

### DIFF
--- a/src/Cake.Coverlet/CoverletTool.cs
+++ b/src/Cake.Coverlet/CoverletTool.cs
@@ -64,7 +64,7 @@ namespace Cake.Coverlet
             argumentBuilder.AppendQuoted(coverageFile.MakeAbsolute(_environment).FullPath);
 
             argumentBuilder.AppendSwitchQuoted("--target", "dotnet");
-            argumentBuilder.AppendSwitchQuoted($"--targetargs", $"test {testProject.MakeAbsolute(_environment)} --no-build");
+            argumentBuilder.AppendSwitchQuoted($"--targetargs", $"test \"{testProject.MakeAbsolute(_environment)}\" --no-build");
 
             ArgumentsProcessor.ProcessToolArguments(settings, _environment, argumentBuilder, testProject);
 

--- a/test/Cake.Coverlet.Tests/CoverletToolTest.cs
+++ b/test/Cake.Coverlet.Tests/CoverletToolTest.cs
@@ -23,7 +23,7 @@ namespace Cake.Coverlet.Tests
             var result = _fixture.Run();
 
             result.Args.Should().StartWith("\"/Working/test/Cake.Coverlet.Tests/bin/Debug/netcoreapp2.1/Cake.Coverlet.Tests.dll\"");
-            result.Args.Should().Contain("--targetargs \"test /Working/test/Cake.Coverlet.Tests --no-build\"");
+            result.Args.Should().Contain("--targetargs \"test \"/Working/test/Cake.Coverlet.Tests\" --no-build\"");
             result.Args.Should().Contain("--format json");
         }
 
@@ -41,7 +41,7 @@ namespace Cake.Coverlet.Tests
             Console.WriteLine(result.Args);
 
             result.Args.Should().StartWith("\"/Working/test/Cake.Coverlet.Tests/bin/Debug/netcoreapp2.1/Cake.Coverlet.Tests.dll\"");
-            result.Args.Should().Contain("--targetargs \"test /Working/test/Cake.Coverlet.Tests --no-build\"");
+            result.Args.Should().Contain("--targetargs \"test \"/Working/test/Cake.Coverlet.Tests\" --no-build\"");
             result.Args.Should().Contain("--format json");
             result.Args.Should().Contain("--exclude-by-attribute \"abc.def\"");
             result.Args.Should().Contain("--exclude-by-attribute \"abc2.def\"");


### PR DESCRIPTION
In the current version there are problems running the coverlet function if the directory contains spaces. This PR fixes the call by adding quotation mark when calling the dotnet test command.