### PR TITLE
Retarget to net6 and Cake.Common 2.2.

### DIFF
--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Coverlet extensions for Cake Build</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cake.Coverlet</AssemblyName>
     <PackageId>Cake.Coverlet</PackageId>
@@ -31,13 +31,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.58" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>  
-        <None Include="..\..\licence.md" Pack="true" PackagePath=""/>
+        <None Include="..\..\licence.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.Coverlet/CoverletAliases.cs
+++ b/src/Cake.Coverlet/CoverletAliases.cs
@@ -1,8 +1,8 @@
 ﻿using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
-using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Test;
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -10,13 +10,13 @@ using System.Collections.Generic;
 namespace Cake.Coverlet
 {
     /// <summary>
-    /// Several extension methods when using DotNetCoreTest.
+    /// Several extension methods when using DotNetTest.
     /// </summary>
-    [CakeAliasCategory("DotNetCore")]
+    [CakeAliasCategory("DotNet")]
     public static class CoverletAliases
     {
         /// <summary>
-        /// Runs DotNetCoreTest using the given <see cref="CoverletSettings"/>
+        /// Runs DotNetTest using the given <see cref="CoverletSettings"/>
         /// </summary>
         /// <param name="context"></param>
         /// <param name="project"></param>
@@ -25,10 +25,10 @@ namespace Cake.Coverlet
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
 
-        public static void DotNetCoreTest(
+        public static void DotNetTest(
             this ICakeContext context,
             FilePath project,
-            DotNetCoreTestSettings settings,
+            DotNetTestSettings settings,
             CoverletSettings coverletSettings)
         {
             if (context == null) {
@@ -41,7 +41,7 @@ namespace Cake.Coverlet
                 currentCustomization?.Invoke(args) ?? args, 
                 project);
 
-            context.DotNetCoreTest(project.FullPath, settings);
+            context.DotNetTest(project.FullPath, settings);
         }
         
         /// <summary>

--- a/src/Cake.Coverlet/CoverletSettings.cs
+++ b/src/Cake.Coverlet/CoverletSettings.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNet;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -18,7 +18,7 @@ namespace Cake.Coverlet
     /// <summary>
     /// Settings used by Cake.Coverlet
     /// </summary>
-    public class CoverletSettings : DotNetCoreSettings
+    public class CoverletSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets if coverage should be collected

--- a/src/Cake.Coverlet/CoverletTool.cs
+++ b/src/Cake.Coverlet/CoverletTool.cs
@@ -15,7 +15,7 @@ namespace Cake.Coverlet
         private readonly ICakeEnvironment _environment;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:Cake.Common.Tools.DotNetCore.VSTest.DotNetCoreVSTester" /> class.
+        /// Initializes a new instance of the <see cref="T:Cake.Common.Tools.DotNet.VSTest.DotNetVSTester" /> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>

--- a/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
+++ b/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="1.0.0" />
+    <PackageReference Include="Cake.Common" Version="2.2.0" />
     <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />


### PR DESCRIPTION
There were no apparent problems with this update.