### PR TITLE
Bump to Cake 4.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,25 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+          
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+
       - name: Nerdbank.GitVersioning
         uses: dotnet/nbgv@v0.4.0
         with:
           setAllVars: true
+
       - name: Run the build script
         uses: cake-build/cake-action@v1
         with:
           target: Pack
+          cake-version: tool-manifest
+
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.0
         if: runner.os == 'Windows'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: Nerdbank.GitVersioning
         uses: dotnet/nbgv@v0.4.0

--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,89 @@ FakesAssemblies/
 
 *.DotSettings
 
+### Rider ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+.idea
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+# End of https://www.toptal.com/developers/gitignore/api/rider
+
 BenchmarkDotNet.Artifacts/
 tools/*
 coverage-results/*

--- a/Cake.Coverlet.sln
+++ b/Cake.Coverlet.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.cake = build.cake
 		readme.md = readme.md
 		version.json = version.json
+		.gitignore = .gitignore
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{EEC95ADF-2D7A-4B97-9D4E-27F2F198FFC6}"

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -20,7 +20,7 @@
     <PackageLicenseFile>licence.md</PackageLicenseFile>
     <PackageIcon>images\icon.png</PackageIcon>
     <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/addin/cake-contrib-addin-medium.png</PackageIconUrl>
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -32,13 +32,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.109" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>  

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -16,6 +16,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/romanx/Cake.Coverlet</PackageProjectUrl>
     <PackageLicenseFile>licence.md</PackageLicenseFile>
     <PackageIcon>images\icon.png</PackageIcon>
@@ -46,7 +47,8 @@
   </ItemGroup>
 
   <ItemGroup>  
-      <None Include="..\..\licence.md" Pack="true" PackagePath="" />
+    <None Include="..\..\licence.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\readme.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -31,6 +31,10 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Coverlet extensions for Cake Build</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cake.Coverlet</AssemblyName>
     <PackageId>Cake.Coverlet</PackageId>

--- a/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
+++ b/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
+++ b/test/Cake.Coverlet.Tests/Cake.Coverlet.Tests.csproj
@@ -6,20 +6,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="3.0.0" />
-    <PackageReference Include="Cake.Testing" Version="3.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Cake.Common" Version="4.0.0" />
+    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.109">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "4.0",
   "publicReleaseRefSpec": [
     "^refs/tags/v\\d\\.\\d", // we also release tags starting with vN.N
     "^refs/heads/main$"


### PR DESCRIPTION
- Updates to Cake 4.0.0
- Updates to latest packages
- Multi-targets to net6.0 and net8.0
- Makes build deterministic
- Embeds symbols in DLL 
- Adds readme in nuget package.

Closes #58 