### PR TITLE
Update to Cake 6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            9.0.x
+            10.0.x
 
       - name: Nerdbank.GitVersioning
         uses: dotnet/nbgv@v0.5.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            9.0.x
+            10.0.x
 
       - name: Nerdbank.GitVersioning
         uses: dotnet/nbgv@v0.5.1

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,17 +5,17 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Build Deps">
-    <PackageVersion Include="Cake.Frosting" Version="5.1.0" />
+    <PackageVersion Include="Cake.Frosting" Version="6.1.0" />
     <PackageVersion Include="Cake.GitHub" Version="1.0.0" />
     <PackageVersion Include="Cake.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Cake.Addin.Analyzer" Version="0.1.3" />
-    <PackageVersion Include="Cake.Common" Version="5.1.0" />
-    <PackageVersion Include="Cake.Testing" Version="5.1.0" />
+    <PackageVersion Include="Cake.Common" Version="6.1.0" />
+    <PackageVersion Include="Cake.Testing" Version="6.1.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
   </ItemGroup>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Cake.Coverlet/Cake.Coverlet.csproj
+++ b/src/Cake.Coverlet/Cake.Coverlet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Coverlet extensions for Cake Build</Description>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cake.Coverlet</AssemblyName>
     <PackageId>Cake.Coverlet</PackageId>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "5.1",
+  "version": "6.0",
   "publicReleaseRefSpec": [
     "^refs/tags/v\\d\\.\\d",
     "^refs/heads/main$"


### PR DESCRIPTION
- build: Add support for .NET 10 and update workflows for compatibility
- build(deps): bump Cake.Frosting, Cake.Common, Cake.Testing, and xunit.v3 to latest versions
- chore: Bump version to 6.0 to match new cake version